### PR TITLE
Unit test coverage for char.js, word.js, and util.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "grunt-mocha-test": "^0.12.7",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
-    "serve-static": "^1.10.0"
+    "serve-static": "^1.10.0",
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0"
   },
   "dependencies": {
     "diff": "1.4.0"

--- a/src/js/block.js
+++ b/src/js/block.js
@@ -147,6 +147,22 @@ Block.prototype = {
 		return word;
 	},
 
+	splitAndInsertBlocks: function (refWord, wordArrays) {
+		// Since we're creating new blocks, we will need to move all
+		// sibling words of this word into the final created block
+		var siblingWords = this.removeWordsAfter(refWord),
+			prevBlock = this;
+
+		wordArrays.forEach(function (words) {
+			prevBlock = prevBlock.insertWordsAfter(words);
+		});
+		// If we have sibling words, they need to added to the end
+		// of the final created block
+		siblingWords.forEach(function (word) {
+			prevBlock.insertAfter(null, word);
+		});
+	},
+
 	getWords: function () {
 		return this.words;
 	},

--- a/src/js/char.js
+++ b/src/js/char.js
@@ -14,11 +14,11 @@ var Util = require('./util');
  * 3. parent
  *    - A reference to its parent Word object.
  */
-var Char = function (char, parent) {
+var Char = function (char, parent, props) {
 	this.parent = parent;
 
 	this.char = char || '';
-	this.props = {};
+	this.props = props || {};
 }
 
 Char.prototype = {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -27,10 +27,6 @@ var Util = {
 		return !!(str && str.match(/^\s+$/) && !this.isNewLine(str));
 	},
 
-	on: function (target, event, listener, useCapture) {
-		target.addEventListener(event, listener, useCapture);
-	},
-
 	createHTMLWordString: function (root) {
 		var skipRoot = false;
 		if (this.blockNames.indexOf(root.nodeName.toLowerCase()) !== -1) {

--- a/src/js/word.js
+++ b/src/js/word.js
@@ -158,17 +158,17 @@ Word.prototype = {
 		}
 
 		// First, let's add any new words to this block
+		var lastWord = this;
 		if (thisBlockWords.length) {
-			var prevWord = this;
 			thisBlockWords.forEach(function (word) {
-				prevWord.parent.insertAfter(prevWord, word);
-				prevWord = word;
+				lastWord.parent.insertAfter(lastWord, word);
+				lastWord = word;
 			});
 		}
 
 		// Now, let's start creating blocks
 		if (newBlocks.length) {
-			this.parent.splitAndInsertBlocks(this, newBlocks);
+			this.parent.splitAndInsertBlocks(lastWord, newBlocks);
 		}
 	},
 

--- a/src/js/word.js
+++ b/src/js/word.js
@@ -168,18 +168,7 @@ Word.prototype = {
 
 		// Now, let's start creating blocks
 		if (newBlocks.length) {
-			var prevBlock = this.parent;
-			// Since we're creating new blocks, we will need to move all
-			// sibling words of this word into the final created block
-			var siblingWords = prevBlock.removeWordsAfter(this);
-			newBlocks.forEach(function (words) {
-				prevBlock = prevBlock.insertWordsAfter(words);
-			});
-			// If we have sibling words, they need to added to the end
-			// of the final created block
-			siblingWords.forEach(function (word) {
-				prevBlock.insertAfter(null, word);
-			});
+			this.parent.splitAndInsertBlocks(this, newBlocks);
 		}
 	},
 

--- a/src/js/word.js
+++ b/src/js/word.js
@@ -249,7 +249,7 @@ Word.prototype = {
 		var index = this.chars.indexOf(char);
 		if (index !== -1) {
 			this.chars.splice(index, 1);
-			char.parent = null;
+			delete char.parent;
 		}
 
 		// If word is empty, remove it
@@ -300,8 +300,8 @@ Word.prototype = {
 			content += next.toHTML();
 		}, this);
 		Object.keys(tags).forEach(function (tag) {
-			pre = '<' + tag + '>' + pre;
-			post = post + '</' + tag + '>';
+			pre = pre + '<' + tag + '>';
+			post = '</' + tag + '>' + post;
 		});
 		return pre + content + post;
 	}

--- a/src/js/word.js
+++ b/src/js/word.js
@@ -171,12 +171,12 @@ Word.prototype = {
 			var prevBlock = this.parent;
 			// Since we're creating new blocks, we will need to move all
 			// sibling words of this word into the final created block
-			var siblingWords = this.parent.removeWordsAfter(this);
+			var siblingWords = prevBlock.removeWordsAfter(this);
 			newBlocks.forEach(function (words) {
 				prevBlock = prevBlock.insertWordsAfter(words);
 			});
 			// If we have sibling words, they need to added to the end
-			// of the final created blocked
+			// of the final created block
 			siblingWords.forEach(function (word) {
 				prevBlock.insertAfter(null, word);
 			});

--- a/src/js/words.js
+++ b/src/js/words.js
@@ -11,13 +11,13 @@ var Words = function (selector) {
 	this.element = document.querySelector(selector);
 	this.element.setAttribute('contenteditable', true);
 
-	Util.on(this.element, 'input', this.onInput.bind(this));
+	this.element.addEventListener('input', this.onInput.bind(this));
 
 	this.doc = new Document(Util.createHTMLWordString(this.element));
 
 	// Attach to click for the toolbar
 	Array.prototype.slice.call(document.querySelectorAll('button')).forEach(function (button) {
-		Util.on(button, 'click', this.onToolbarButtonClick.bind(this));
+		button.addEventListener('click', this.onToolbarButtonClick.bind(this));
 	}, this);
 
 	if (TreeUX) {

--- a/test/unit/char.spec.js
+++ b/test/unit/char.spec.js
@@ -1,4 +1,3 @@
-var assert = require('chai').assert;
 var expect = require('chai').expect;
 
 var Char = require('../../src/js/char');
@@ -19,13 +18,24 @@ describe('Char', function () {
 			expect(char.props).to.be.empty;
 		});
 
-		it('should aceept a character and a parent reference', function () {
+		it('should accept a character and a parent reference', function () {
 			var tempParent = {},
 				tempChar = 'X',
 				char = new Char('X', tempParent);
 
 			expect(char.char).to.equal(tempChar);
 			expect(char.parent).to.equal(tempParent);
+		});
+
+		it('should accept props as an object', function () {
+			var props = {
+					'b': true,
+					'i': false
+				},
+				char = new Char('X', null, props);
+
+			expect(char.props).to.equal(props);
+			expect(char.getProps()).to.deep.equal(['b']);
 		});
 	});
 

--- a/test/unit/util.spec.js
+++ b/test/unit/util.spec.js
@@ -1,0 +1,49 @@
+var expect = require('chai').expect;
+
+var Util = require('../../src/js/util');
+
+describe('Util', function () {
+	describe('exists', function () {
+		it('should return true for empty string false and 0', function () {
+			expect(Util.exists('')).to.be.true;
+			expect(Util.exists(false)).to.be.true;
+			expect(Util.exists(0)).to.be.true;
+		});
+
+		it('should return false for null and undefined', function () {
+			expect(Util.exists(undefined)).to.be.false;
+			expect(Util.exists(null)).to.be.false;
+		});
+
+		it('should return false for a deleted property', function () {
+			var obj = { prop: false };
+			expect(Util.exists(obj.prop)).to.be.true;
+
+			delete obj.prop;
+			expect(Util.exists(obj.prop)).to.be.false;
+		});
+	});
+
+	describe('isNewLine', function () {
+		it('should return true for \\n', function () {
+			expect(Util.isNewLine('\n')).to.be.true;
+			expect(Util.isNewLine('\r')).to.be.false;
+			expect(Util.isNewLine(' ')).to.be.false;
+		});
+	});
+
+	describe('isSpace', function () {
+		it('should return true for spaces', function () {
+			var whiteSpaces = [' ', '\t', '\v', '\f', '\u00A0', '\u2000', '\u2001', '\u2002', '\u2003','\u2028', '\u2029'];
+
+			whiteSpaces.forEach(function (str) {
+				expect(Util.isSpace(str)).to.be.true;
+			});
+		});
+
+		it('should return false for new line chars and empty strings', function () {
+			expect(Util.isSpace('\n')).to.be.false;
+			expect(Util.isSpace('')).to.be.false;
+		});
+	});
+});

--- a/test/unit/word.spec.js
+++ b/test/unit/word.spec.js
@@ -302,7 +302,7 @@ describe('Word', function () {
 			expect(parent.otherWord.toString()).to.equal('morechars ');
 		});
 
-		it('should split a Word into multiple words if there are multiple space before the end of the Word', function () {
+		it('should split a Word into multiple words if there are multiple spaces before the end of the Word', function () {
 			var parent = {
 					otherWords: [],
 					insertAfter: function (refWord, otherWord) {
@@ -340,9 +340,45 @@ describe('Word', function () {
 			expect(parent.otherWord).to.be.null;
 		});
 
-		// TODO: Should test splitting word that contains newlines
-		// However, the code should be refactored to not make multiple calls
-		// to different methods on parent object, so refactor and then make tests
+		it('should split a Word into multiple Blocks and Words when it contains newlines and spaces', function () {
+			var parent = {
+					words: [],
+					otherBlocks: [],
+					refWord: null,
+					splitAndInsertBlocks: function (refWord, wordArrays) {
+						this.refWord = refWord;
+						wordArrays.forEach(function (wordArray) {
+							this.otherBlocks.push(wordArray);
+						}, this);
+					},
+					insertAfter: function (prevWord, word) {
+						var index = this.words.indexOf(prevWord);
+						this.words.splice(index + 1, 0, word);
+						word.parent = this;
+					}
+				},
+				word = new Word('block one\nblock two\nblock three', parent);
+
+			parent.words = [word];
+
+			word.split();
+			expect(word.parent).to.equal(parent);
+			expect(word.toString()).to.equal('block ');
+			expect(parent.words.length).to.equal(2);
+			expect(parent.words[0]).to.equal(word);
+			var secondWord = parent.words[1];
+			expect(secondWord.toString()).to.equal('one\n');
+			expect(parent.refWord).to.equal(secondWord);
+			expect(parent.otherBlocks.length).to.equal(2);
+			var blockTwo = parent.otherBlocks[0];
+			expect(blockTwo.length).to.equal(2);
+			expect(blockTwo[0].toString()).to.equal('block ');
+			expect(blockTwo[1].toString()).to.equal('two\n');
+			var blockThree = parent.otherBlocks[1];
+			expect(blockThree.length).to.equal(2);
+			expect(blockThree[0].toString()).to.equal('block ');
+			expect(blockThree[1].toString()).to.equal('three');
+		});
 	});
 
 	describe('merge', function () {

--- a/test/unit/word.spec.js
+++ b/test/unit/word.spec.js
@@ -1,0 +1,284 @@
+var chai = require('chai');
+var sinon = require('sinon');
+chai.use(require('sinon-chai'));
+var expect = chai.expect;
+
+var Word = require('../../src/js/word');
+var Char = require('../../src/js/char');
+
+describe('Word', function () {
+	describe('constructor', function () {
+		it('should exist', function () {
+			expect(Word).not.to.be.undefined;
+		});
+
+		it('should accept an array of Char objects and set their parent reference', function () {
+			var chars = [new Char('a'), new Char(' ')],
+				word = new Word(chars);
+
+			expect(word.chars).to.be.an.instanceof(Array);
+			expect(word.chars).to.equal(chars);
+			expect(word.chars[0].parent).to.equal(word);
+			expect(word.chars[1].parent).to.equal(word);
+		});
+
+		it('should accept a string and convert it into Chars', function () {
+			var str = 'chars ',
+				word = new Word(str);
+
+			expect(word.chars).to.be.an.instanceof(Array);
+			expect(word.chars.length).to.equal(6);
+
+			word.chars.forEach(function (char, idx) {
+				expect(char).to.be.an.instanceof(Char);
+				expect(char.toString()).to.equal(str[idx]);
+				expect(char.parent).to.equal(word);
+			});
+		});
+
+		it('should accept a parent reference', function () {
+			var obj = {},
+				word = new Word('a ', obj);
+
+			expect(word.parent).to.equal(obj);
+		});
+
+		it('should create an empty Char when passed an empty string', function () {
+			var str = '',
+				word = new Word('');
+
+			expect(word.chars.length).to.equal(1);
+			expect(word.chars[0]).to.be.an.instanceof(Char);
+			expect(word.chars[0].toString()).to.be.empty;
+			expect(word.chars[0].parent).to.equal(word);
+		});
+
+		it('should have an empty char array by default', function () {
+			var word = new Word();
+
+			expect(word.chars).to.be.an.instanceof(Array);
+			expect(word.chars.length).to.equal(0);
+		});
+	});
+
+	describe('getChars', function () {
+		it('should return the chars array', function () {
+			var chars = [new Char('a'), new Char(' ')],
+				word = new Word(chars);
+
+			expect(word.getChars()).to.equal(chars);
+		});
+	});
+
+	describe('getFirstChar', function () {
+		it('should return the first Char', function () {
+			var chars = [new Char('a'), new Char(' ')],
+				word = new Word(chars);
+
+			expect(word.getFirstChar()).to.equal(chars[0]);
+		});
+	});
+
+	describe('getLastChar', function () {
+		it('should return the last Char', function () {
+			var chars = [new Char('a'), new Char(' ')],
+				word = new Word(chars);
+
+			expect(word.getLastChar()).to.equal(chars[1]);
+		});
+	});
+
+	describe('removeChar', function () {
+		it('should remove the provided Char and return it', function () {
+			var word = new Word('chars '),
+				target = word.chars[2];
+
+			expect(word.chars.length).to.equal(6);
+			expect(target.parent).to.equal(word);
+
+			var returned = word.removeChar(target);
+			expect(returned).to.equal(target);
+			expect(returned.parent).to.be.undefined;
+			expect(word.chars.length).to.equal(5);
+			expect(word.toString()).to.equal('chrs ');
+		});
+
+		it('should not change anything if the provided Char is not the word', function () {
+			var char = new Char('a'),
+				word = new Word('chars '),
+				returned = word.removeChar(char);
+
+			expect(returned).to.equal(char);
+			expect(word.toString()).to.equal('chars ');
+		});
+
+		it('should call removeWord on its parent if all Chars are removed', function () {
+			var parent = {
+					removeWord: sinon.spy()
+				},
+				word = new Word('a ', parent);
+
+			expect(word.chars.length).to.equal(2);
+
+			var returned = word.removeChar(word.chars[0]);
+			expect(returned.parent).to.be.undefined;
+			expect(word.chars.length).to.equal(1);
+			expect(parent.removeWord).not.to.have.been.called;
+
+			returned = word.removeChar(word.chars[0]);
+			expect(returned.parent).to.be.undefined;
+			expect(word.chars.length).to.equal(0);
+			expect(parent.removeWord).to.have.been.calledWith(word);
+		});
+	});
+
+	describe('toJSON', function () {
+		it('should return a JSON representation of the Word when initialized with a string', function () {
+			var word = new Word('chars '),
+				json = word.toJSON(0);
+
+			expect(json).to.deep.equal({
+				name: 'w',
+				id: 'w0',
+				children: [
+					{ name: 'c', id: 'c0-0', children: [] },
+					{ name: 'h', id: 'c0-1', children: [] },
+					{ name: 'a', id: 'c0-2', children: [] },
+					{ name: 'r', id: 'c0-3', children: [] },
+					{ name: 's', id: 'c0-4', children: [] },
+					{ name: '[ ]', id: 'c0-5', children: [] }
+				]
+			});
+		});
+
+		it('should return a JSON representation of the Word when initialized with an array of Chars', function () {
+			var chars = [new Char('c', null, { 'b': true }), new Char('h'), new Char('a'), new Char('r'), new Char('s'), new Char(' ')],
+				word = new Word(chars),
+				json = word.toJSON(0);
+
+			expect(json).to.deep.equal({
+				name: 'w',
+				id: 'w0',
+				children: [
+					{ name: 'c', id: 'c0-0', children: ['b'] },
+					{ name: 'h', id: 'c0-1', children: [] },
+					{ name: 'a', id: 'c0-2', children: [] },
+					{ name: 'r', id: 'c0-3', children: [] },
+					{ name: 's', id: 'c0-4', children: [] },
+					{ name: '[ ]', id: 'c0-5', children: [] }
+				]
+			});
+		});
+
+		it('should return a JSON representation when the Word is empty', function () {
+			var word = new Word(undefined),
+				json = word.toJSON(1);
+
+			expect(json).to.deep.equal({
+				name: 'w',
+				id: 'w1',
+				children: []
+			});
+		});
+
+		it('should return a JSON representation when the Word is just an empty string', function () {
+			var word = new Word(''),
+				json = word.toJSON(0);
+
+			expect(json).to.deep.equal({
+				name: 'w',
+				id: 'w0',
+				children: [{ name: '', id: 'c0-0', children: [] }]
+			});
+		});
+	});
+
+	describe('toString', function () {
+		it('should return the characters converted into a string', function () {
+			var str = 'chars ',
+				word = new Word(str),
+				res = word.toString();
+
+			expect(word.chars[0]).to.be.an.instanceof(Char);
+			expect(res).to.be.a('string');
+			expect(res).to.equal(str);
+		});
+	});
+
+	describe('toHTML', function () {
+		it('should return the characters converted into a string', function () {
+			var str = 'chars ',
+				word = new Word(str),
+				res = word.toHTML();
+
+			expect(word.chars[0]).to.be.an.instanceof(Char);
+			expect(res).to.be.a('string');
+			expect(res).to.equal(str);
+		});
+
+		it('should return the characters converted into a string wrapped in tags based on props of Chars', function () {
+			var chars = [
+					new Char('c', null, { 'b': true }),
+					new Char('h', null, { 'i': true }),
+					new Char('a'),
+					new Char('r', null, { 'sup': true }),
+					new Char('s', null, { 'sup': false, 'sub': true }),
+					new Char(' ')
+				],
+				word = new Word(chars),
+				res = word.toHTML();
+
+			expect(res).to.be.a('string');
+			expect(res).to.equal('<b><i><sup><sub>chars </sub></sup></i></b>');
+		});
+	});
+
+	describe('toggleProp', function () {
+		it('should turn on a prop for all child Chars', function () {
+			var word = new Word('chars ');
+
+			word.chars.forEach(function (char) {
+				expect(char.props).to.deep.equal({});
+			});
+
+			word.toggleProp('b');
+			word.chars.forEach(function (char) {
+				expect(char.props).to.deep.equal({ 'b': true });
+			});
+		});
+
+		it('should set prop to true for all child Chars if only some are true already', function () {
+			var chars = [
+					new Char('c', null, { 'b': true }),
+					new Char('h', null, { 'b': true }),
+					new Char('a'),
+					new Char('r', null, { 'b': true }),
+					new Char('s', null, { 'b': true }),
+					new Char(' ')
+				],
+				word = new Word(chars);
+
+			word.toggleProp('b');
+			word.chars.forEach(function (char) {
+				expect(char.props['b']).to.be.true;
+			});
+		});
+
+		it('should set prop to false if all child Chars are already true', function () {
+			var chars = [
+					new Char('c', null, { 'b': true }),
+					new Char('h', null, { 'b': true }),
+					new Char('a', null, { 'b': true }),
+					new Char('r', null, { 'b': true }),
+					new Char('s', null, { 'b': true }),
+					new Char(' ', null, { 'b': true })
+				],
+				word = new Word(chars);
+
+				word.toggleProp('b');
+				word.chars.forEach(function (char) {
+					expect(char.props['b']).to.be.false;
+				});
+		});
+	});
+});


### PR DESCRIPTION
- Add sinon & sinon-chai dev dependencies for testing
- Unit tests which cover 100% of `char.js` and `word.js`
- Unit tests which cover all methods of Util which don't require some browser functionality (ie document, window, etc.)
- Fix a tricky bug in `word.split()` (uncovered by unit tests, yay!)
- Move some logic around splitting words between word & block
- Get rid of `Util.on` helper
- A few other minor tweaks/fixes to code
